### PR TITLE
Add Abstract Assembly IR and Code Emission Framework

### DIFF
--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -1,0 +1,81 @@
+use crate::lexer::Token;
+use crate::parser::{Block, Expr, FnDeclaration, Program, Statement, VarDeclaration};
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct AbstractAssemblyProgram {
+    pub instructions: Vec<AbstractAssemblyInstruction>,
+}
+
+#[derive(Debug)]
+pub enum AbstractAssemblyInstruction {
+    BinOp {
+        op: Token,
+        dest: Dest,
+        src1: Operand,
+        src2: Operand,
+    },
+    UnOp {
+        op: Token,
+        dest: Dest,
+        src: Operand,
+    },
+    Mov {
+        dest: Dest,
+        src: Operand,
+    },
+}
+
+#[derive(Debug)]
+pub enum Dest {
+    Register(usize),
+    Temp(usize),
+}
+
+#[derive(Debug)]
+pub enum Operand {
+    Const(i128),
+    Var(Dest),
+}
+
+/// Context for a function
+pub struct Context {
+    /// Name of function this context is for
+    name: String,
+    /// Largest temp number that has not been used
+    temp_counter: usize,
+    /// Largest label number that has not been used
+    label_counter: usize,
+    /// Given a variable name, get the associated temp
+    var_to_temp: HashMap<String, Dest>,
+}
+
+impl Context {
+    pub fn new(name: &str) -> Self {
+        Context {
+            name: name.to_string(),
+            temp_counter: 0,
+            label_counter: 0,
+            var_to_temp: HashMap::new(),
+        }
+    }
+
+    pub fn generate(&mut self, fn_declaration: &FnDeclaration) -> AbstractAssemblyProgram {
+        let mut instructions = Vec::new();
+
+        AbstractAssemblyProgram { instructions }
+    }
+
+    fn new_temp(&mut self) -> String {
+        let temp = format!("%t{}", self.temp_counter);
+        self.temp_counter += 1;
+        temp
+    }
+
+    /// Generates a new label name
+    fn new_label(&mut self) -> String {
+        let label = format!("L{}", self.label_counter);
+        self.label_counter += 1;
+        label
+    }
+}

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -3,11 +3,6 @@ use crate::parser::{Block, Expr, FnDeclaration, Program, Statement, VarDeclarati
 use std::collections::HashMap;
 
 #[derive(Debug)]
-pub struct AbstractAssemblyProgram {
-    pub instructions: Vec<AbstractAssemblyInstruction>,
-}
-
-#[derive(Debug)]
 pub enum AbstractAssemblyInstruction {
     BinOp {
         op: Token,
@@ -41,40 +36,109 @@ pub enum Operand {
 /// Context for a function
 pub struct Context {
     /// Name of function this context is for
-    name: String,
+    pub name: String,
+    /// Abstract assembly instructions this function compiles into
+    pub instructions: Vec<AbstractAssemblyInstruction>,
     /// Largest temp number that has not been used
     temp_counter: usize,
     /// Largest label number that has not been used
     label_counter: usize,
     /// Given a variable name, get the associated temp
-    var_to_temp: HashMap<String, Dest>,
+    var_to_temp: HashMap<String, usize>,
 }
 
 impl Context {
     pub fn new(name: &str) -> Self {
         Context {
             name: name.to_string(),
+            instructions: Vec::new(),
             temp_counter: 0,
             label_counter: 0,
             var_to_temp: HashMap::new(),
         }
     }
 
-    pub fn generate(&mut self, fn_declaration: &FnDeclaration) -> AbstractAssemblyProgram {
-        let mut instructions = Vec::new();
+    pub fn generate(&mut self, fn_declaration: &FnDeclaration) {
+        for statement in &fn_declaration.body.statements {
+            match statement {
+                Statement::VarDecl(declr) => {
+                    if let Token::Identifier(varname) = &declr.identifier {
+                        // Create temp for new variable
+                        let dest_temp = self.new_temp();
+                        self.var_to_temp.insert(varname.clone(), dest_temp);
+                        let dest = Dest::Temp(dest_temp);
 
-        AbstractAssemblyProgram { instructions }
+                        // Compute the expression, populate in temp
+                        let src = self.generate_expr(&declr.value);
+                        self.instructions
+                            .push(AbstractAssemblyInstruction::Mov { dest, src });
+                    } else {
+                        panic!("Invalid identifier"); // Better error handling here
+                    }
+                }
+                _ => unimplemented!("Unsupported statement"),
+            }
+        }
     }
 
-    fn new_temp(&mut self) -> String {
-        let temp = format!("%t{}", self.temp_counter);
+    /// Returns the location that the result is stored in
+    fn generate_expr(&mut self, expr: &Expr) -> Operand {
+        match expr {
+            Expr::Literal(literal) => match literal {
+                // TODO: handle Doubles
+                Token::Number(num) => Operand::Const(*num as i128),
+                _ => panic!("Invalid literal"),
+            },
+            Expr::Unary(op, src) => {
+                let src_operand = self.generate_expr(src);
+                let dest_temp = self.new_temp();
+                let dest = Dest::Temp(dest_temp);
+                self.instructions.push(AbstractAssemblyInstruction::UnOp {
+                    op: op.clone(),
+                    dest,
+                    src: src_operand,
+                });
+                Operand::Var(Dest::Temp(dest_temp))
+            }
+            Expr::Binary(left, op, right) => {
+                let left_operand = self.generate_expr(left);
+                let right_operand = self.generate_expr(right);
+                let dest_temp = self.new_temp();
+                let dest = Dest::Temp(dest_temp);
+                self.instructions.push(AbstractAssemblyInstruction::BinOp {
+                    op: op.clone(),
+                    dest,
+                    src1: left_operand,
+                    src2: right_operand,
+                });
+                Operand::Var(Dest::Temp(dest_temp))
+            }
+            Expr::Parentheses(expr) => self.generate_expr(expr),
+            Expr::Variable(token) => {
+                if let Token::Identifier(varname) = token {
+                    if let Some(&temp) = self.var_to_temp.get(varname) {
+                        Operand::Var(Dest::Temp(temp))
+                    } else {
+                        panic!("Undefined variable: {}", varname);
+                    }
+                } else {
+                    panic!("Invalid variable token");
+                }
+            }
+            _ => panic!("Unsupported expression"),
+        }
+    }
+
+    /// Generates a new temp
+    fn new_temp(&mut self) -> usize {
+        let temp = self.temp_counter.clone();
         self.temp_counter += 1;
         temp
     }
 
     /// Generates a new label name
-    fn new_label(&mut self) -> String {
-        let label = format!("L{}", self.label_counter);
+    fn new_label(&mut self) -> usize {
+        let label = self.label_counter.clone();
         self.label_counter += 1;
         label
     }

--- a/src/codegen/emit.rs
+++ b/src/codegen/emit.rs
@@ -1,8 +1,23 @@
-use super::context::Context;
+use super::context::{AbstractAssemblyInstruction, Context, Dest, Operand};
+use crate::lexer::Token;
 use crate::parser::VarDeclaration;
 use std::fs::File;
 use std::io::{self, Write};
 use std::path::PathBuf;
+
+fn serialize_dest(dest: &Dest) -> String {
+    match dest {
+        Dest::Register(reg) => format!("({})", reg),
+        Dest::Temp(temp) => format!("%t{}", temp),
+    }
+}
+
+fn serialize_operand(operand: &Operand) -> String {
+    match operand {
+        Operand::Const(value) => format!("${}", value),
+        Operand::Var(dest) => format!("{}", serialize_dest(dest)),
+    }
+}
 
 pub fn emit_abstract(
     outpath: &PathBuf,
@@ -10,6 +25,52 @@ pub fn emit_abstract(
     globals: &Vec<VarDeclaration>,
 ) -> io::Result<()> {
     let mut file = File::create(&outpath)?;
+    for context in func_contexts {
+        file.write_all(format!(".{}\n", context.name).as_bytes());
+        for instruction in &context.instructions {
+            let line = match instruction {
+                AbstractAssemblyInstruction::BinOp {
+                    op,
+                    dest,
+                    src1,
+                    src2,
+                } => {
+                    format!(
+                        "{} <- {} {} {}\n",
+                        serialize_dest(&dest),
+                        serialize_operand(&src1),
+                        match op {
+                            Token::Plus => "+",
+                            Token::Minus => "-",
+                            Token::Star => "*",
+                            Token::Slash => "/",
+                            _ => unimplemented!("Unsupported binary operation"),
+                        },
+                        serialize_operand(&src2)
+                    )
+                }
+                AbstractAssemblyInstruction::UnOp { op, dest, src } => {
+                    format!(
+                        "{} <- {}{}\n",
+                        serialize_dest(&dest),
+                        match op {
+                            Token::Bang => "!",
+                            Token::Minus => "-",
+                            Token::Tilde => "~",
+                            _ => unimplemented!("Unsupported unary operation"),
+                        },
+                        serialize_operand(&src)
+                    )
+                }
+                AbstractAssemblyInstruction::Mov { dest, src } => {
+                    format!("{} <- {}\n", serialize_dest(&dest), serialize_operand(&src))
+                }
+            };
+
+            file.write_all(line.as_bytes())?;
+        }
+    }
+
     Ok(())
 }
 

--- a/src/codegen/emit.rs
+++ b/src/codegen/emit.rs
@@ -1,0 +1,32 @@
+use super::context::Context;
+use crate::parser::VarDeclaration;
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+pub fn emit_abstract(
+    outpath: &PathBuf,
+    func_contexts: &Vec<Context>,
+    globals: &Vec<VarDeclaration>,
+) -> io::Result<()> {
+    let mut file = File::create(&outpath)?;
+    Ok(())
+}
+
+pub fn emit_x86(
+    outpath: &PathBuf,
+    func_contexts: &Vec<Context>,
+    globals: &Vec<VarDeclaration>,
+) -> io::Result<()> {
+    let mut file = File::create(&outpath)?;
+    Ok(())
+}
+
+pub fn emit_m6502(
+    outpath: &PathBuf,
+    func_contexts: &Vec<Context>,
+    globals: &Vec<VarDeclaration>,
+) -> io::Result<()> {
+    let mut file = File::create(&outpath)?;
+    Ok(())
+}

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -20,6 +20,7 @@ pub enum Token {
     Minus,
     Star,
     Slash,
+    Tilde,
 
     // One or two character tokens
     Less,
@@ -141,6 +142,7 @@ pub fn tokenize_from_string(contents: &str) -> Vec<Token> {
             '-' => tokens.push(Token::Minus),
             '*' => tokens.push(Token::Star),
             '/' => tokens.push(Token::Slash),
+            '~' => tokens.push(Token::Tilde),
             '<' => {
                 if let Some('=') = chars.peek() {
                     chars.next();

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,6 @@ fn compile_the_thing(config: Config) -> Result<(), CompileError> {
                 filename: filename.to_string(),
                 source: e,
             })?;
-            let ops = codegen::generate_code(program);
 
             // Construct the output path: src_dir/target/filename.o0
             let mut outpath = PathBuf::from(&config.src_dir);
@@ -134,12 +133,12 @@ fn compile_the_thing(config: Config) -> Result<(), CompileError> {
             outpath.set_extension("S");
 
             // Write the output file
-            codegen::to_file(ops, outpath.clone()).map_err(|e| {
-                CompileError::BinaryFileGenerationError {
+            codegen::generate_code(program, codegen::Target::AbstractAssembly, &outpath).map_err(
+                |e| CompileError::BinaryFileGenerationError {
                     outpath: outpath.to_string_lossy().into(),
                     source: e,
-                }
-            })?;
+                },
+            )?;
 
             Ok(())
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -347,7 +347,7 @@ impl Parser {
     }
 
     fn unary(&mut self) -> Result<Expr, ParserError> {
-        if self.match_token(&[Token::Bang, Token::Minus]) {
+        if self.match_token(&[Token::Bang, Token::Minus, Token::Tilde]) {
             let operator = self.previous();
             let right = self.unary()?;
             return Ok(Expr::Unary(operator, Box::new(right)));


### PR DESCRIPTION
**This PR**
* Defined an intermediate representation (IR) for abstract assembly
* Implemented a code generator that converts our `Program` AST into abstract assembly instructions, on a per-function basis
* Outlined a plan for global variables and function calls 
* Created a skeleton for emitting code to different targets (e.g., abstract assembly, x86)

**Test Plan**
The following program `samples/declarations_only.c0`
```
int main() {
    int a = 0;
    int b = (1+1)*2;
    int c = 2+3*4+5+a;
}
```
produces the following abstract assembly under `samples/target/declarations_only.S`; ignore the `.S` extension:
```
.main
%t0 <- $0
%t2 <- $1 + $1
%t3 <- %t2 * $2
%t1 <- %t3
%t5 <- $3 * $4
%t6 <- $2 + %t5
%t7 <- %t6 + $5
%t8 <- %t7 + %t0
%t4 <- %t8
```

**Follow-up PR**
* Abstract assembly: handle doubles and strings, basic control flow (conditionals, jumps), function calls
* Translation from abstract assembly to x86
* Proper error handling
* A lot of things, yeah